### PR TITLE
fix: import Nuxt composables from `#imports`

### DIFF
--- a/src/runtime/composables/useDevice.ts
+++ b/src/runtime/composables/useDevice.ts
@@ -1,4 +1,4 @@
-import { useNuxtApp } from '#app'
+import { useNuxtApp } from '#imports'
 import type { Device } from '../types'
 
 export const useDevice = (): Device => {

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,4 +1,4 @@
-import { defineNuxtPlugin, useRuntimeConfig, useRequestHeaders } from '#app'
+import { defineNuxtPlugin, useRuntimeConfig, useRequestHeaders } from '#imports'
 import { reactive } from 'vue'
 import generateFlags from './generateFlags'
 


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.