### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,16 @@ This module injects flags that indicate a device type into the context and the c
 
 See [demo on CodeSandbox](https://codesandbox.io/s/github/nuxt-community/device-module).
 
-## Setup for Nuxt3
-
-If you use Nuxt2.x use [@nuxtjs/device 2.x](https://github.com/nuxt-community/device-module/tree/v2.1.0).
-
-Add `@nuxtjs/device` to the dev dependencies using yarn or npm to your project.
+## Installation
 
 ```bash
 npx nuxi@latest module add device
 ```
 
-Add it to the `modules` section of your `nuxt.config`:
-
-```js
-{
-  modules: [
-   '@nuxtjs/device',
-  ]
-}
-```
-
 That's it, you can now use `$device` in your [Nuxt](https://nuxtjs.org) app ✨
+
+> [!NOTE]
+> You can find the Nuxt 2 version of the module on the [`2.x` branch](https://github.com/nuxt-community/device-module/tree/v2.1.0).
 
 ## Flags
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ See [demo on CodeSandbox](https://codesandbox.io/s/github/nuxt-community/device-
 npx nuxi@latest module add device
 ```
 
-That's it, you can now use `$device` in your [Nuxt](https://nuxtjs.org) app ✨
-
 > [!NOTE]
 > You can find the Nuxt 2 version of the module on the [`2.x` branch](https://github.com/nuxt-community/device-module/tree/v2.1.0).
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,7 @@ If you use Nuxt2.x use [@nuxtjs/device 2.x](https://github.com/nuxt-community/de
 Add `@nuxtjs/device` to the dev dependencies using yarn or npm to your project.
 
 ```bash
-yarn add --dev @nuxtjs/device
-# Using npm
-npm install -D @nuxtjs/device
+npx nuxi@latest module add device
 ```
 
 Add it to the `modules` section of your `nuxt.config`:


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
