### PR TITLE
feat: deprecate `refreshOnResize` option

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { defu } from 'defu'
-import { defineNuxtModule, addPlugin, addImportsDir, createResolver } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, addImportsDir, createResolver, useLogger } from '@nuxt/kit'
 import { name, version } from '../package.json'
 import type { ModuleOptions } from './types'
 
@@ -19,6 +19,12 @@ export default defineNuxtModule<ModuleOptions>({
     refreshOnResize: false,
   },
   setup(options, nuxt) {
+    if (typeof options.refreshOnResize === 'boolean') {
+      const logger = useLogger('@nuxtjs/device')
+
+      logger.warn('\'refreshOnResize\' option is deprecated. It will be removed in the next major release.')
+    }
+
     if (!options.enabled) {
       return
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,22 +1,20 @@
 export interface ModuleOptions {
   /**
-   * Enable Device Module
+   * Whether to enable the module conditionally.
    * @default true
-   * @type boolean
    */
   enabled?: boolean
 
   /**
    * Device Module Default User Agent
    * @default 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.39 Safari/537.36'
-   * @type string
    */
   defaultUserAgent?: string
 
   /**
    * Refresh Device Module Values On Window Resize
    * @default false
-   * @type boolean
+   * @deprecated
    */
   refreshOnResize?: boolean
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt-modules/device/issues/210
resolves https://github.com/nuxt-modules/device/issues/176
resolves https://github.com/nuxt-modules/device/issues/90

### 📚 Description

Deprecates the `refreshOnResize` option.
