### PR TITLE
feat: add `isLinux` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ You can use the following flags to detect the device type:
 - `$device.isMobileOrTablet`
 - `$device.isDesktopOrTablet`
 - `$device.isIos`
+- `$device.isLinux`
 - `$device.isWindows`
 - `$device.isMacOS`
 - `$device.isApple`

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -7,6 +7,7 @@
     <p>isMobileOrTablet: {{ device.isMobileOrTablet ? '✅':'❌' }}</p>
     <p>isDesktopOrTablet: {{ device.isDesktopOrTablet ? '✅':'❌' }}</p>
     <p>isTablet: {{ device.isTablet ? '✅':'❌' }}</p>
+    <p>isLinux: {{ device.isLinux ? '✅':'❌' }}</p>
     <p>isWindows: {{ device.isWindows ? '✅':'❌' }}</p>
     <p>isMacOS: {{ device.isMacOS ? '✅':'❌' }}</p>
     <p>isApple: {{ device.isApple ? '✅':'❌' }}</p>

--- a/src/runtime/generateFlags.ts
+++ b/src/runtime/generateFlags.ts
@@ -37,6 +37,9 @@ function isMacOS(userAgent: string): boolean {
   return /Mac OS X/.test(userAgent)
 }
 
+function isLinux(userAgent: string): boolean {
+  return /Linux/i.test(userAgent) && !isAndroid(userAgent)
+}
 // Following regular expressions are originated from bowser(https://github.com/lancedikson/bowser).
 // Copyright 2015, Dustin Diaz (the "Original Author")
 // https://github.com/lancedikson/bowser/blob/master/LICENSE
@@ -116,6 +119,7 @@ export default function generateFlags(userAgent: string, headers: Record<string,
 
   const windows = isWindows(userAgent)
   const macOS = isMacOS(userAgent)
+  const linux = isLinux(userAgent)
   const browserName = getBrowserName(userAgent)
   const isSafari = browserName === 'Safari'
   const isFirefox = browserName === 'Firefox'
@@ -133,6 +137,7 @@ export default function generateFlags(userAgent: string, headers: Record<string,
     isIos: ios,
     isAndroid: android,
     isWindows: windows,
+    isLinux: linux,
     isMacOS: macOS,
     isApple: macOS || ios,
     isDesktopOrTablet: !mobile,

--- a/src/runtime/generateFlags.ts
+++ b/src/runtime/generateFlags.ts
@@ -40,6 +40,7 @@ function isMacOS(userAgent: string): boolean {
 function isLinux(userAgent: string): boolean {
   return /Linux/i.test(userAgent) && !isAndroid(userAgent)
 }
+
 // Following regular expressions are originated from bowser(https://github.com/lancedikson/bowser).
 // Copyright 2015, Dustin Diaz (the "Original Author")
 // https://github.com/lancedikson/bowser/blob/master/LICENSE

--- a/src/runtime/types.ts
+++ b/src/runtime/types.ts
@@ -7,6 +7,7 @@ export type Device = {
   isMobileOrTablet: boolean
   isDesktopOrTablet: boolean
   isTablet: boolean
+  isLinux: boolean
   isWindows: boolean
   isMacOS: boolean
   isApple: boolean

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -16,6 +16,7 @@ function parseHtml(html: string) {
     isIos: findTrueOrFalse(html, 'isIos: '),
     isWindows: findTrueOrFalse(html, 'isWindows: '),
     isMacOS: findTrueOrFalse(html, 'isMacOS: '),
+    isLinux: findTrueOrFalse(html, 'isLinux: '),
     isApple: findTrueOrFalse(html, 'isApple: '),
     isAndroid: findTrueOrFalse(html, 'isAndroid: '),
     isFirefox: findTrueOrFalse(html, 'isFirefox: '),
@@ -49,6 +50,7 @@ describe('ssr', async () => {
     expect(html).toContain('isIos')
     expect(html).toContain('isWindows')
     expect(html).toContain('isMacOS')
+    expect(html).toContain('isLinux')
     expect(html).toContain('isApple')
     expect(html).toContain('isAndroid')
     expect(html).toContain('isFirefox')
@@ -69,9 +71,9 @@ describe('ssr', async () => {
         },
       })
 
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isChrome } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isChrome } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isChrome }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: true, isIos: false, isMacOS: false, isWindows: false, isChrome: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isChrome }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: true, isIos: false, isMacOS: false, isLinux: false, isWindows: false, isChrome: true })
     })
 
     it('Apple iPhone X', async () => {
@@ -83,9 +85,9 @@ describe('ssr', async () => {
         },
       })
 
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: false, isIos: true, isMacOS: true, isWindows: false, isSafari: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: false, isIos: true, isMacOS: true, isLinux: false, isWindows: false, isSafari: true })
     })
 
     it('Samsung Galaxy Tab S3', async () => {
@@ -96,9 +98,9 @@ describe('ssr', async () => {
           'User-Agent': userAgent,
         },
       })
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isChrome } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isChrome } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isChrome }).toEqual({ isMobile: false, isMobileOrTablet: true, isAndroid: true, isIos: false, isMacOS: false, isWindows: false, isChrome: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isChrome }).toEqual({ isMobile: false, isMobileOrTablet: true, isAndroid: true, isIos: false, isMacOS: false, isLinux: false, isWindows: false, isChrome: true })
     })
 
     it('Windows 10-based PC using Edge browser', async () => {
@@ -109,9 +111,22 @@ describe('ssr', async () => {
           'User-Agent': userAgent,
         },
       })
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isEdge } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isEdge } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isEdge }).toEqual({ isMobile: false, isMobileOrTablet: false, isAndroid: false, isIos: false, isMacOS: false, isWindows: true, isEdge: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isEdge }).toEqual({ isMobile: false, isMobileOrTablet: false, isAndroid: false, isIos: false, isMacOS: false, isLinux: false, isWindows: true, isEdge: true })
+    })
+
+    it('Linux PC using Chrome browser', async () => {
+      const userAgent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36'
+
+      const html = await $fetch('/', {
+        headers: {
+          'User-Agent': userAgent,
+        },
+      })
+      const { isChrome, isFirefox, isEdge, isSafari, isSamsung, isMacOS, isLinux, isWindows } = parseHtml(html)
+
+      expect({ isChrome, isFirefox, isEdge, isSafari, isSamsung, isMacOS, isLinux, isWindows }).toEqual({ isChrome: true, isFirefox: false, isEdge: false, isSafari: false, isSamsung: false, isMacOS: false, isLinux: true, isWindows: false })
     })
 
     it('Mac OS X-based computer using a Safari browser', async () => {
@@ -122,9 +137,9 @@ describe('ssr', async () => {
           'User-Agent': userAgent,
         },
       })
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari }).toEqual({ isMobile: false, isMobileOrTablet: false, isAndroid: false, isIos: false, isMacOS: true, isWindows: false, isSafari: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari }).toEqual({ isMobile: false, isMobileOrTablet: false, isAndroid: false, isIos: false, isMacOS: true, isLinux: false, isWindows: false, isSafari: true })
     })
   })
 
@@ -215,9 +230,9 @@ describe('ssr', async () => {
           'User-Agent': userAgent,
         },
       })
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: false, isIos: true, isMacOS: true, isWindows: false, isSafari: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: false, isIos: true, isMacOS: true, isLinux: false, isWindows: false, isSafari: true })
     })
     it('Facebook', async () => {
       const userAgent
@@ -228,9 +243,9 @@ describe('ssr', async () => {
           'User-Agent': userAgent,
         },
       })
-      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari } = parseHtml(html)
+      const { isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari } = parseHtml(html)
 
-      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isWindows, isSafari }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: false, isIos: true, isMacOS: true, isWindows: false, isSafari: true })
+      expect({ isMobile, isMobileOrTablet, isAndroid, isIos, isMacOS, isLinux, isWindows, isSafari }).toEqual({ isMobile: true, isMobileOrTablet: true, isAndroid: false, isIos: true, isMacOS: true, isLinux: false, isWindows: false, isSafari: true })
     })
   })
 

--- a/test/fixtures/basic/pages/index.vue
+++ b/test/fixtures/basic/pages/index.vue
@@ -9,6 +9,7 @@
     <p>isTablet: {{ device.isTablet ? '✅':'❌' }}</p>
     <p>isWindows: {{ device.isWindows ? '✅':'❌' }}</p>
     <p>isMacOS: {{ device.isMacOS ? '✅':'❌' }}</p>
+    <p>isLinux: {{ device.isLinux ? '✅':'❌' }}</p>
     <p>isApple: {{ device.isApple ? '✅':'❌' }}</p>
     <p>isAndroid: {{ device.isAndroid ? '✅':'❌' }}</p>
     <p>isSafari: {{ device.isSafari ? '✅':'❌' }}</p>


### PR DESCRIPTION
### 🔗 Linked issue
resolves https://github.com/nuxt-modules/device/issues/236

### 📚 Description

- Adding a new device validation: Linux
  - Validate that is Linux and not an Android device
- Update and add unit tests
- Update redme

